### PR TITLE
feat: Add GitHub Actions workflow for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release Build and Deploy
+
+on:
+  release:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+  PROJECT_NAME: sailr # Assuming 'sailr' from completion/sailr.bash
+
+jobs:
+  build_and_upload_release_assets:
+    name: Build and Upload for ${{ matrix.platform.os_name }} (${{ matrix.platform.target }})
+    runs-on: ${{ matrix.platform.os_runner }}
+    strategy:
+      matrix:
+        platform:
+          - os_name: Linux
+            os_runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_ext: ""
+            archive_ext: ".tar.gz"
+          - os_name: Linux_ARM64
+            os_runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary_ext: ""
+            archive_ext: ".tar.gz"
+          - os_name: macOS
+            os_runner: macos-latest # This should provide x86_64
+            target: x86_64-apple-darwin
+            binary_ext: ""
+            archive_ext: ".tar.gz"
+          - os_name: macOS_ARM64
+            os_runner: macos-latest # newer macos-latest M1 runners can build for arm64
+            target: aarch64-apple-darwin
+            binary_ext: ""
+            archive_ext: ".tar.gz"
+          - os_name: Windows
+            os_runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary_ext: ".exe"
+            archive_ext: ".zip"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.platform.target }}
+          override: true
+
+      - name: Install dependencies for Linux ARM64 cross-compilation
+        if: matrix.platform.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build binary
+        run: cargo build --release --locked --target ${{ matrix.platform.target }}
+        env:
+          # For aarch64-unknown-linux-gnu, specify the linker
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
+
+      - name: Prepare artifact name and staging directory
+        id: prep_artifact
+        run: |
+          VERSION=$(echo "${{ github.ref_name }}" | sed 's/v//') # Remove 'v' prefix if present
+          ARTIFACT_NAME="${{ env.PROJECT_NAME }}-${VERSION}-${{ matrix.platform.target }}"
+          ARTIFACT_PATH_SUFFIX="target/${{ matrix.platform.target }}/release/${{ env.PROJECT_NAME }}${{ matrix.platform.binary_ext }}"
+          
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
+          echo "ARTIFACT_PATH=./${ARTIFACT_NAME}" >> $GITHUB_ENV
+          echo "ARTIFACT_SOURCE_BINARY_PATH=${ARTIFACT_PATH_SUFFIX}" >> $GITHUB_ENV
+
+          mkdir -p ./${ARTIFACT_NAME}
+          echo "Created staging directory: ./${ARTIFACT_NAME}"
+
+      - name: List files in target directory (for debugging)
+        run: |
+          ls -R target/${{ matrix.platform.target }}/release/
+          echo "Expected binary path: ${{ env.ARTIFACT_SOURCE_BINARY_PATH }}"
+        shell: bash
+        
+      - name: Copy files to staging directory
+        run: |
+          cp "${{ env.ARTIFACT_SOURCE_BINARY_PATH }}" "./${{ env.ARTIFACT_NAME }}/"
+          # Attempt to copy LICENSE and README.md, ignore if they don't exist at the root
+          # In a real scenario, these paths might need to be adjusted if they are not in the repo root
+          cp LICENSE "./${{ env.ARTIFACT_NAME }}/" || echo "LICENSE file not found, skipping."
+          cp README.md "./${{ env.ARTIFACT_NAME }}/" || echo "README.md file not found, skipping."
+        shell: bash # Use bash for `||` operator
+
+      - name: Package artifact (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Compress-Archive -Path "./${{ env.ARTIFACT_NAME }}/*" -DestinationPath "./${{ env.ARTIFACT_NAME }}${{ matrix.platform.archive_ext }}"
+          echo "ARCHIVE_PATH=./${{ env.ARTIFACT_NAME }}${{ matrix.platform.archive_ext }}" >> $GITHUB_ENV
+
+      - name: Package artifact (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          tar -czvf "./${{ env.ARTIFACT_NAME }}${{ matrix.platform.archive_ext }}" -C "./${{ env.ARTIFACT_NAME }}" .
+          echo "ARCHIVE_PATH=./${{ env.ARTIFACT_NAME }}${{ matrix.platform.archive_ext }}" >> $GITHUB_ENV
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.ARCHIVE_PATH }}
+          asset_name: ${{ env.ARTIFACT_NAME }}${{ matrix.platform.archive_ext }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow in `.github/workflows/release.yml`.

The workflow is designed to automate the building and deployment of release binaries when a new release is created in the repository.

Key features:
- Triggers on new release creation (`on: release: types: [created]`).
- Sets up build environments for Linux (x86_64, ARM64), macOS (x86_64, ARM64), and Windows (x86_64).
- Uses a matrix strategy to build for each platform and architecture.
- Compiles the Rust project using `cargo build --release`.
- Packages the compiled binary along with LICENSE and README.md into platform-appropriate archives (.zip for Windows, .tar.gz for Linux/macOS).
- Artifact names include project name, version (from tag), and target triple.
- Uploads the packaged archives as assets to the corresponding GitHub Release.
- Basic error handling is provided by GitHub Actions' default behavior (job fails on script error).

This workflow streamlines the release process by ensuring that binaries for major platforms are automatically built and made available with each new release.