### PR TITLE
feat: Add deployment strategy option to deploy and go commands

### DIFF
--- a/docs/docs/cli-usage.md
+++ b/docs/docs/cli-usage.md
@@ -127,13 +127,22 @@ Tears down the infrastructure for an environment.
 
 Deploys an existing, generated environment to a Kubernetes cluster. This command applies the manifests found in `./k8s/generated/<NAME>/`.
 
-*   **Usage:** `sailr deploy --name <NAME> --context <CONTEXT>`
+*   **Usage:** `sailr deploy --name <NAME> --context <CONTEXT> [--strategy <STRATEGY>]`
 *   **Options:**
     *   `-n, --name <NAME>`: (Required) Name of the environment to deploy.
     *   `-c, --context <CONTEXT>`: (Required) The Kubernetes cluster context to deploy to (as listed in your kubeconfig).
+    *   `--strategy <STRATEGY>`: Specifies the deployment strategy to use.
+        *   Possible values: `Restart`, `Rolling`.
+        *   Defaults to `Restart`.
+        *   `Restart`: Before applying new manifests, this strategy first deletes any existing Kubernetes Deployments that are defined in the environment's generated files. This ensures that associated pods are cleanly restarted with the new version.
+        *   `Rolling`: This strategy applies the new manifests and relies on Kubernetes to perform a standard rolling update if the Deployment resources are configured for it (this is the default update strategy for Kubernetes Deployments). Sailr does not perform any explicit deletions of resources with this strategy.
 *   **Example:**
     ```bash
+    # Deploy with the default Restart strategy
     sailr deploy --name production --context prod-cluster
+
+    # Deploy using a Rolling update strategy
+    sailr deploy --name staging --context stage-cluster --strategy Rolling
     ```
 
 ---
@@ -186,18 +195,27 @@ Builds container images for services defined in an environment's `config.toml` t
 A comprehensive command that performs a sequence of actions:
 1.  Builds container images for services (respecting `--force`, `--ignore`, `--only`).
 2.  Generates Kubernetes manifests (respecting `--only`, `--ignore` based on the services selected for building/processing).
-3.  Deploys the generated manifests to the specified Kubernetes cluster.
+3.  Deploys the generated manifests to the specified Kubernetes cluster using the chosen deployment strategy.
 
-*   **Usage:** `sailr go [OPTIONS] --name <NAME> --context <CONTEXT>`
+*   **Usage:** `sailr go [OPTIONS] --name <NAME> --context <CONTEXT> [--strategy <STRATEGY>]`
 *   **Options:**
     *   `-n, --name <NAME>`: (Required) Name of the environment.
     *   `-c, --context <CONTEXT>`: (Required) The Kubernetes cluster context to deploy to.
     *   `-f, --force`: Force rebuild of all images during the build phase.
     *   `-i, --ignore <SERVICES>`: Comma-separated list of service names to ignore for build and manifest generation phases.
     *   `--only <SERVICES>`: Comma-separated list of service names to process for build and manifest generation phases.
+    *   `--strategy <STRATEGY>`: Specifies the deployment strategy to use for the deployment phase.
+        *   Possible values: `Restart`, `Rolling`.
+        *   Defaults to `Restart`.
+        *   `Restart`: Ensures a clean redeployment by first deleting existing Kubernetes Deployments (managed by Sailr for this environment, based on generated manifests) before applying the new ones.
+        *   `Rolling`: Relies on Kubernetes' standard rolling update mechanism based on the manifest configurations.
 *   **Example:**
     ```bash
+    # Run 'go' with the default Restart strategy for deployment, processing only api and frontend
     sailr go --name staging --context stage-cluster --force --only api,frontend
+
+    # Run 'go' using a Rolling update strategy for deployment
+    sailr go --name production --context prod-cluster --strategy Rolling
     ```
 
 ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,6 +134,9 @@ pub struct ApplyArgs {
         help = "Name of the environment"
     )]
     pub name: String,
+
+    #[arg(long = "strategy", help = "Deployment strategy to use", default_value_t = DeploymentStrategy::Restart, value_enum)]
+    pub strategy: DeploymentStrategy,
 }
 
 #[derive(Debug, Args)]
@@ -187,6 +190,12 @@ pub enum Provider {
     Local,
     Aws,
     Gcp,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum DeploymentStrategy {
+    Restart,
+    Rolling,
 }
 
 pub fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
@@ -300,6 +309,9 @@ pub struct GoArgs {
 
     #[arg(long, short)]
     pub only: Option<String>,
+
+    #[arg(long = "strategy", help = "Deployment strategy to use for the deploy step", default_value_t = DeploymentStrategy::Restart, value_enum)]
+    pub strategy: DeploymentStrategy,
 }
 
 #[derive(Debug, Args)]
@@ -404,4 +416,175 @@ pub struct AddServiceArgs {
 
     #[arg(short = 'n', long = "name", help = "Environment to add the service to")]
     pub env_name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deploy_args_strategy_restart() {
+        let cli = Cli::try_parse_from(&[
+            "sailr",
+            "deploy",
+            "--context",
+            "test-context",
+            "--name",
+            "test-env",
+            "--strategy",
+            "Restart",
+        ])
+        .unwrap();
+        match cli.commands {
+            Commands::Deploy(args) => {
+                assert_eq!(args.strategy, DeploymentStrategy::Restart);
+                assert_eq!(args.context, "test-context");
+                assert_eq!(args.name, "test-env");
+            }
+            _ => panic!("Expected Deploy command"),
+        }
+    }
+
+    #[test]
+    fn test_deploy_args_strategy_rolling() {
+        let cli = Cli::try_parse_from(&[
+            "sailr",
+            "deploy",
+            "--context",
+            "test-context",
+            "--name",
+            "test-env",
+            "--strategy",
+            "Rolling",
+        ])
+        .unwrap();
+        match cli.commands {
+            Commands::Deploy(args) => {
+                assert_eq!(args.strategy, DeploymentStrategy::Rolling);
+                assert_eq!(args.context, "test-context");
+                assert_eq!(args.name, "test-env");
+            }
+            _ => panic!("Expected Deploy command"),
+        }
+    }
+
+    #[test]
+    fn test_deploy_args_strategy_default() {
+        // Assumes DeploymentStrategy::Restart is the default
+        let cli = Cli::try_parse_from(&[
+            "sailr",
+            "deploy",
+            "--context",
+            "test-context",
+            "--name",
+            "test-env",
+        ])
+        .unwrap();
+        match cli.commands {
+            Commands::Deploy(args) => {
+                assert_eq!(args.strategy, DeploymentStrategy::Restart);
+                assert_eq!(args.context, "test-context");
+                assert_eq!(args.name, "test-env");
+            }
+            _ => panic!("Expected Deploy command"),
+        }
+    }
+
+    #[test]
+    fn test_deploy_args_strategy_invalid() {
+        let result = Cli::try_parse_from(&[
+            "sailr",
+            "deploy",
+            "--context",
+            "test-context",
+            "--name",
+            "test-env",
+            "--strategy",
+            "InvalidStrategy",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_go_args_strategy_restart() {
+        let cli = Cli::try_parse_from(&[
+            "sailr",
+            "go",
+            "--context",
+            "test-context",
+            "--name",
+            "test-env",
+            "--strategy",
+            "Restart",
+        ])
+        .unwrap();
+        match cli.commands {
+            Commands::Go(args) => {
+                assert_eq!(args.strategy, DeploymentStrategy::Restart);
+                assert_eq!(args.context, "test-context");
+                assert_eq!(args.name, "test-env");
+            }
+            _ => panic!("Expected Go command"),
+        }
+    }
+
+    #[test]
+    fn test_go_args_strategy_rolling() {
+        let cli = Cli::try_parse_from(&[
+            "sailr",
+            "go",
+            "--context",
+            "test-context",
+            "--name",
+            "test-env",
+            "--strategy",
+            "Rolling",
+        ])
+        .unwrap();
+        match cli.commands {
+            Commands::Go(args) => {
+                assert_eq!(args.strategy, DeploymentStrategy::Rolling);
+                assert_eq!(args.context, "test-context");
+                assert_eq!(args.name, "test-env");
+            }
+            _ => panic!("Expected Go command"),
+        }
+    }
+
+    #[test]
+    fn test_go_args_strategy_default() {
+        // Assumes DeploymentStrategy::Restart is the default
+        let cli = Cli::try_parse_from(&[
+            "sailr",
+            "go",
+            "--context",
+            "test-context",
+            "--name",
+            "test-env",
+        ])
+        .unwrap();
+        match cli.commands {
+            Commands::Go(args) => {
+                assert_eq!(args.strategy, DeploymentStrategy::Restart);
+                assert_eq!(args.context, "test-context");
+                assert_eq!(args.name, "test-env");
+            }
+            _ => panic!("Expected Go command"),
+        }
+    }
+
+    #[test]
+    fn test_go_args_strategy_invalid() {
+        let result = Cli::try_parse_from(&[
+            "sailr",
+            "go",
+            "--context",
+            "test-context",
+            "--name",
+            "test-env",
+            "--strategy",
+            "InvalidStrategy",
+        ]);
+        assert!(result.is_err());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ async fn main() -> Result<(), CliError> {
         Commands::Deploy(arg) => {
             LOGGER.info(&format!("Deploying an environment"));
 
-            sailr::deployment::deploy(arg.context.to_string(), &arg.name).await?;
+            sailr::deployment::deploy(arg.context.to_string(), &arg.name, arg.strategy).await?;
         }
         Commands::Generate(arg) => {
             LOGGER.info(&format!("Generating an environment"));
@@ -322,7 +322,7 @@ async fn main() -> Result<(), CliError> {
 
             generate(&arg.name, &env, services);
 
-            sailr::deployment::deploy(arg.context.to_string(), &arg.name).await?;
+            sailr::deployment::deploy(arg.context.to_string(), &arg.name, arg.strategy).await?;
         }
         Commands::K8s(args) => {
             match args.command {


### PR DESCRIPTION
This commit introduces a `--strategy` command-line option for both the `sailr deploy` and `sailr go` commands. This allows you to specify the desired method for deploying applications.

The following strategies are supported:
- `Restart` (default): This strategy first deletes any existing Kubernetes Deployments that are managed by Sailr for the current environment (as defined in the generated manifest files). It then applies the new manifests, ensuring a clean redeployment of associated pods.
- `Rolling`: This strategy applies the new manifests and relies on Kubernetes to perform a standard rolling update if the Deployment resources are configured for it. Sailr does not perform any explicit deletions with this strategy.

Changes include:
- Added `DeploymentStrategy` enum in `src/cli.rs`.
- Added `--strategy` argument to `DeployArgs` and `GoArgs` in `src/cli.rs`.
- Modified the core `deployment::deploy` function in `src/deployment/mod.rs` to implement the Restart and Rolling logic. The Restart strategy now identifies deployments to delete by parsing the generated manifest files for the environment.
- Updated `src/main.rs` to pass the strategy from CLI arguments to the `deployment::deploy` function for both `deploy` and `go` commands.
- Added CLI parsing tests for the `--strategy` argument in both `DeployArgs` and `GoArgs`.
- Outlined integration tests for the core deployment logic in `src/deployment/mod.rs`.
- Updated `docs/docs/cli-usage.md` to document the new `--strategy` option for both `sailr deploy` and `sailr go` commands.