### PR TITLE
feat: Add timeout to Kubernetes client

### DIFF
--- a/src/deployment/k8sm8/mod.rs
+++ b/src/deployment/k8sm8/mod.rs
@@ -14,6 +14,7 @@ pub mod services;
 pub mod statefulsets;
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Result;
 
@@ -41,9 +42,12 @@ pub async fn create_client(context: String) -> Result<kube::Client, KubeError> {
         cluster: None,
         user: None,
     };
-    let config = kube::Config::from_kubeconfig(&options)
+    let mut config = kube::Config::from_kubeconfig(&options)
         .await
         .map_err(|e| KubeError::UnexpectedError(format!("Failed to create client: {}", e)))?;
+
+    config.connect_timeout = Some(Duration::from_secs(10));
+
     let client = Client::try_from(config)
         .map_err(|e| KubeError::UnexpectedError(format!("Failed to create client: {}", e)))?;
 
@@ -59,10 +63,13 @@ pub async fn get_cluster_resources(
     let client = create_client(context.to_string()).await?;
 
     // Discover the available API resources from the cluster.
-    let discovery = Discovery::new(client.clone())
-        .run()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to discover API resources: {}", e))?;
+    let discovery = Discovery::new(client.clone());
+
+    let discovery = match tokio::time::timeout(Duration::from_secs(10), discovery.run()).await {
+        Ok(Ok(d)) => d,
+        Ok(Err(e)) => return Err(anyhow::anyhow!("Failed to discover API resources: {}", e)),
+        Err(_) => return Err(anyhow::anyhow!("Failed to discover API resources: timed out")),
+    };
 
     let gvk = if let Some(tm) = resource_type.types.clone() {
         GroupVersionKind::try_from(tm).map_err(|e| {


### PR DESCRIPTION
This change adds a 10-second timeout to the Kubernetes client and discovery process. This will prevent the application from hanging when the Kubernetes API server is not reachable, which can happen when connecting over a slow network like Tailscale.

This addresses the "service unavailable" error reported by the user.

Note: This change does not fix the existing test failures. The test failures are unrelated to this change and should be addressed in a separate pull request.